### PR TITLE
feat: 添加小爱音箱扫码登录功能

### DIFF
--- a/server/src/controllers/misound.controller.js
+++ b/server/src/controllers/misound.controller.js
@@ -1,0 +1,187 @@
+/**
+ * 小爱音箱渠道控制器
+ *
+ * 提供扫码登录、设备列表查询、绑定确认等接口
+ */
+
+const XiaomiAuthService = require('../services/xiaomi-auth.service');
+const ChannelService = require('../services/channel.service');
+const ResponseUtil = require('../utils/response');
+const logger = require('../utils/logger');
+
+// 临时存储扫码登录的会话数据（内存缓存，5 分钟过期）
+// key: 随机 sessionId, value: { lpUrl, cookies, createdAt }
+const loginSessions = new Map();
+const SESSION_TTL = 5 * 60 * 1000; // 5 分钟
+
+// 定期清理过期会话
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, session] of loginSessions) {
+    if (now - session.createdAt > SESSION_TTL) {
+      loginSessions.delete(key);
+    }
+  }
+}, 60 * 1000);
+
+/**
+ * 生成随机 sessionId
+ */
+function generateSessionId() {
+  return require('crypto').randomBytes(16).toString('hex');
+}
+
+class MisoundController {
+  /**
+   * 初始化扫码登录
+   *
+   * POST /api/channels/misound/qr/init
+   *
+   * 返回二维码 URL 和 sessionId（用于后续轮询）
+   */
+  static async initQRLogin(req, res) {
+    try {
+      const qrData = await XiaomiAuthService.initQRLogin();
+
+      // 创建会话，保存长轮询 URL 和 Cookie
+      const sessionId = generateSessionId();
+      loginSessions.set(sessionId, {
+        lpUrl: qrData.lpUrl,
+        cookies: qrData.cookies,
+        createdAt: Date.now(),
+      });
+
+      return ResponseUtil.success(res, {
+        sessionId,
+        qrCodeUrl: qrData.qrCodeUrl,
+        loginUrl: qrData.loginUrl,
+        timeout: qrData.timeout,
+      }, '获取二维码成功');
+    } catch (error) {
+      logger.error('[Misound] 获取扫码二维码失败:', error.message);
+      return ResponseUtil.serverError(res, '获取二维码失败: ' + error.message);
+    }
+  }
+
+  /**
+   * 轮询扫码状态
+   *
+   * GET /api/channels/misound/qr/status?sessionId=xxx
+   *
+   * 长轮询等待用户扫码结果，成功后返回 userId 和 passToken
+   */
+  static async pollQRStatus(req, res) {
+    try {
+      const { sessionId } = req.query;
+      if (!sessionId) {
+        return ResponseUtil.badRequest(res, 'sessionId 参数不能为空');
+      }
+
+      const session = loginSessions.get(sessionId);
+      if (!session) {
+        return ResponseUtil.badRequest(res, '会话已过期，请重新获取二维码');
+      }
+
+      // 调用小米 API 长轮询
+      const result = await XiaomiAuthService.completeLogin(session.lpUrl, session.cookies);
+
+      if (result.status === 'confirmed') {
+        // 登录成功，清理会话
+        loginSessions.delete(sessionId);
+
+        return ResponseUtil.success(res, {
+          status: 'confirmed',
+          userId: result.userId,
+          passToken: result.passToken,
+        });
+      }
+
+      // 未扫码或失败
+      return ResponseUtil.success(res, {
+        status: result.status,
+        message: result.message || '',
+      });
+    } catch (error) {
+      logger.error('[Misound] 轮询扫码状态失败:', error.message);
+      return ResponseUtil.serverError(res, '查询扫码状态失败: ' + error.message);
+    }
+  }
+
+  /**
+   * 确认绑定并创建渠道
+   *
+   * POST /api/channels/misound/qr/confirm
+   *
+   * 使用扫码获取的凭证和用户手动输入的设备名称创建 Misound 渠道
+   */
+  static async confirmBind(req, res) {
+    try {
+      const { userId, passToken, did, name, ttsMode } = req.body;
+
+      if (!userId || !passToken) {
+        return ResponseUtil.badRequest(res, '缺少登录凭证');
+      }
+      if (!did) {
+        return ResponseUtil.badRequest(res, '请输入设备名称');
+      }
+
+      // 创建渠道，配置中存储扫码获取的凭证
+      const channel = await ChannelService.createChannel(req.user.userId, {
+        channelType: 'misound',
+        name: name || '小爱音箱',
+        config: {
+          userId,
+          passToken,
+          did,
+          ttsMode: ttsMode || 'auto',
+        },
+      });
+
+      logger.info(`[Misound] 用户 ${req.user.userId} 扫码绑定成功: did=${did}`);
+
+      return ResponseUtil.created(res, channel, '绑定成功');
+    } catch (error) {
+      logger.error('[Misound] 绑定失败:', error.message);
+      return ResponseUtil.badRequest(res, error.message);
+    }
+  }
+
+  /**
+   * 重新绑定已有渠道
+   *
+   * PUT /api/channels/misound/qr/:channelId/rebind
+   *
+   * 使用新的扫码凭证更新已有渠道的配置
+   */
+  static async rebindChannel(req, res) {
+    try {
+      const channelId = parseInt(req.params.channelId);
+      const { userId, passToken, did, ttsMode } = req.body;
+
+      if (!userId || !passToken) {
+        return ResponseUtil.badRequest(res, '缺少登录凭证');
+      }
+
+      const channel = await ChannelService.updateChannel(channelId, req.user.userId, {
+        config: {
+          userId,
+          passToken,
+          did: did || '',
+          ttsMode: ttsMode || 'auto',
+        },
+      });
+
+      logger.info(`[Misound] 用户 ${req.user.userId} 重新绑定渠道 ${channelId}`);
+
+      return ResponseUtil.success(res, channel, '重新绑定成功');
+    } catch (error) {
+      if (error.message === '渠道不存在') {
+        return ResponseUtil.notFound(res, error.message);
+      }
+      logger.error('[Misound] 重新绑定失败:', error.message);
+      return ResponseUtil.badRequest(res, error.message);
+    }
+  }
+}
+
+module.exports = MisoundController;

--- a/server/src/routes/misound.routes.js
+++ b/server/src/routes/misound.routes.js
@@ -1,0 +1,24 @@
+/**
+ * 小爱音箱渠道路由
+ *
+ * 提供扫码登录、绑定确认等接口
+ * 所有接口均需 JWT 认证
+ */
+
+const express = require('express');
+const router = express.Router();
+const misoundController = require('../controllers/misound.controller');
+
+// 初始化扫码登录（获取二维码）
+router.post('/qr/init', misoundController.initQRLogin);
+
+// 轮询扫码状态（长轮询等待用户扫码）
+router.get('/qr/status', misoundController.pollQRStatus);
+
+// 确认绑定（创建渠道）
+router.post('/qr/confirm', misoundController.confirmBind);
+
+// 重新绑定已有渠道
+router.put('/qr/:channelId/rebind', misoundController.rebindChannel);
+
+module.exports = router;

--- a/server/src/services/xiaomi-auth.service.js
+++ b/server/src/services/xiaomi-auth.service.js
@@ -1,0 +1,441 @@
+/**
+ * 小米云认证服务
+ *
+ * 实现小米账号的扫码登录流程，参考：
+ * https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor
+ *
+ * 流程：
+ * 1. 获取扫码登录的二维码 URL
+ * 2. 长轮询等待用户扫码确认
+ * 3. 从响应中提取 passToken / userId / ssecurity
+ * 4. 通过 location URL 获取 serviceToken
+ * 5. 调用小米云 API 获取音箱设备列表
+ */
+
+const crypto = require('crypto');
+const axios = require('axios');
+const { HttpsProxyAgent } = require('https-proxy-agent');
+const { SocksProxyAgent } = require('socks-proxy-agent');
+const logger = require('../utils/logger');
+
+// 小米账号认证相关常量
+const XIAOMI_ACCOUNT_URL = 'https://account.xiaomi.com';
+const XIAOMI_SID = 'xiaomiio';
+const XIAOMI_CALLBACK = 'https://sts.api.io.mi.com/sts';
+const QR_SIZE = 480;
+const POLL_TIMEOUT = 300; // 长轮询超时（秒）
+
+// 小米云 API 区域服务器
+const REGION_SERVERS = {
+  cn: 'https://api.io.mi.com',
+  de: 'https://de.api.io.mi.com',
+  us: 'https://us.api.io.mi.com',
+  ru: 'https://ru.api.io.mi.com',
+  tw: 'https://tw.api.io.mi.com',
+  sg: 'https://sg.api.io.mi.com',
+  in: 'https://in.api.io.mi.com',
+  i2: 'https://i2.api.io.mi.com',
+};
+
+/**
+ * 根据环境变量创建代理 Agent
+ */
+function createProxyAgent() {
+  const proxyUrl = process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.ALL_PROXY;
+  if (!proxyUrl) return undefined;
+
+  try {
+    const url = new URL(proxyUrl);
+    const protocol = url.protocol.replace(':', '').toLowerCase();
+    if (protocol === 'socks' || protocol === 'socks5' || protocol === 'socks4') {
+      return new SocksProxyAgent(proxyUrl);
+    }
+    return new HttpsProxyAgent(proxyUrl);
+  } catch (e) {
+    logger.warn(`代理配置无效: ${proxyUrl}`);
+    return undefined;
+  }
+}
+
+/**
+ * 生成随机 User-Agent（模拟小米手机浏览器）
+ */
+function generateUserAgent() {
+  const agents = [
+    'Mozilla/5.0 (Linux; Android 14; 2304FPN6DC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+    'Mozilla/5.0 (Linux; Android 13; 2210132C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36',
+    'Mozilla/5.0 (Linux; Android 12; M2102J2SC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Mobile Safari/537.36',
+  ];
+  return agents[Math.floor(Math.random() * agents.length)];
+}
+
+/**
+ * 从 JSONP 响应中提取 JSON 数据
+ * 小米 API 返回格式：jsonpcallback({...})
+ */
+function extractJsonFromJsonp(text) {
+  const match = text.match(/\{.*\}/s);
+  if (!match) {
+    throw new Error('无法解析 JSONP 响应');
+  }
+  return JSON.parse(match[0]);
+}
+
+/**
+ * 小米云认证服务
+ */
+class XiaomiAuthService {
+  /**
+   * 创建带默认配置的 axios 实例
+   */
+  static _createClient(cookieJar = {}) {
+    const proxyAgent = createProxyAgent();
+    const client = axios.create({
+      timeout: 30000,
+      maxRedirects: 0, // 不自动跟随重定向，手动处理 Cookie
+      validateStatus: (status) => status >= 200 && status < 400,
+      headers: {
+        'User-Agent': generateUserAgent(),
+        'Accept': '*/*',
+        'Accept-Language': 'zh-CN,zh;q=0.9',
+      },
+      ...(proxyAgent ? { httpsAgent: proxyAgent, httpAgent: proxyAgent } : {}),
+    });
+
+    // 请求拦截器：注入 Cookie
+    client.interceptors.request.use((config) => {
+      const cookieStr = Object.entries(cookieJar)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('; ');
+      if (cookieStr) {
+        config.headers.Cookie = cookieStr;
+      }
+      return config;
+    });
+
+    // 响应拦截器：提取 Set-Cookie
+    client.interceptors.response.use(
+      (response) => {
+        const setCookies = response.headers['set-cookie'];
+        if (setCookies) {
+          for (const cookie of setCookies) {
+            const [kv] = cookie.split(';');
+            const eqIdx = kv.indexOf('=');
+            if (eqIdx > 0) {
+              const key = kv.slice(0, eqIdx).trim();
+              const val = kv.slice(eqIdx + 1).trim();
+              cookieJar[key] = val;
+            }
+          }
+        }
+        return response;
+      },
+      (error) => {
+        // 3xx 重定向也需要提取 Cookie
+        if (error.response && error.response.headers['set-cookie']) {
+          const setCookies = error.response.headers['set-cookie'];
+          for (const cookie of setCookies) {
+            const [kv] = cookie.split(';');
+            const eqIdx = kv.indexOf('=');
+            if (eqIdx > 0) {
+              const key = kv.slice(0, eqIdx).trim();
+              const val = kv.slice(eqIdx + 1).trim();
+              cookieJar[key] = val;
+            }
+          }
+        }
+        // 对于 3xx 重定向，返回响应（location URL）
+        if (error.response && error.response.status >= 300 && error.response.status < 400) {
+          return error.response;
+        }
+        throw error;
+      }
+    );
+
+    return client;
+  }
+
+  /**
+   * 步骤 1：获取扫码登录的二维码信息
+   *
+   * @returns {{ qr: string, lp: string, loginUrl: string, timeout: number }}
+   *   - qr: 二维码图片 URL
+   *   - lp: 长轮询 URL（用于等待扫码结果）
+   *   - loginUrl: 登录页面 URL（备选，可直接在浏览器打开）
+   *   - timeout: 二维码有效期（秒）
+   */
+  static async getLoginQR() {
+    const cookieJar = {};
+    const client = this._createClient(cookieJar);
+    const dc = Date.now();
+
+    const qs = encodeURIComponent(`?sid=${XIAOMI_SID}&_json=true`);
+    const callback = encodeURIComponent(XIAOMI_CALLBACK);
+
+    const url = `${XIAOMI_ACCOUNT_URL}/longPolling/loginUrl?_qrsize=${QR_SIZE}&qs=${qs}&callback=${callback}&_hasLogo=false&sid=${XIAOMI_SID}&serviceParam=&_locale=zh_CN&_dc=${dc}`;
+
+    logger.info('[XiaomiAuth] 正在获取扫码登录二维码...');
+
+    const response = await client.get(url);
+    const data = extractJsonFromJsonp(response.data);
+
+    if (!data.lp || !data.loginUrl) {
+      throw new Error('获取二维码信息失败：响应缺少必要字段');
+    }
+
+    // loginUrl 本身就是二维码内容，可直接用 qrcode.vue 渲染
+    const loginUrl = data.loginUrl;
+    const lpUrl = data.lp;
+    const timeout = data.timeout || POLL_TIMEOUT;
+
+    logger.info('[XiaomiAuth] 二维码获取成功');
+
+    return {
+      qr: loginUrl,    // 二维码内容（URL）
+      lp: lpUrl,       // 长轮询 URL
+      loginUrl,        // 登录 URL
+      timeout,         // 超时时间
+      _cookies: cookieJar, // 内部使用的 Cookie（需要保存用于后续轮询）
+    };
+  }
+
+  /**
+   * 步骤 2：长轮询等待用户扫码结果
+   *
+   * @param {string} lpUrl - 长轮询 URL（从 getLoginQR 返回）
+   * @param {Object} cookies - 之前获取的 Cookie
+   * @returns {{ status: string, userId?: string, passToken?: string, ssecurity?: string, location?: string }}
+   */
+  static async pollScanStatus(lpUrl, cookies = {}) {
+    const client = this._createClient(cookies);
+
+    logger.info('[XiaomiAuth] 开始长轮询等待扫码...');
+
+    const response = await client.get(lpUrl, {
+      timeout: (POLL_TIMEOUT + 30) * 1000, // 长轮询超时比服务端多 30 秒
+    });
+
+    const data = extractJsonFromJsonp(response.data);
+
+    // 扫码状态：code=0 表示成功
+    if (data.code !== 0) {
+      // 扫码失败或超时
+      const statusMap = {
+        70016: 'expired',     // 二维码已过期
+        70023: 'expired',     // 二维码已失效
+        87009: 'canceled',    // 用户取消
+      };
+      return {
+        status: statusMap[data.code] || 'failed',
+        message: data.desc || '扫码失败',
+      };
+    }
+
+    // 扫码成功，提取凭证
+    logger.info('[XiaomiAuth] 扫码登录成功，正在提取凭证...');
+
+    return {
+      status: 'confirmed',
+      userId: data.userId ? String(data.userId) : '',
+      passToken: data.passToken || '',
+      ssecurity: data.ssecurity || '',
+      location: data.location || '',
+      cUserId: data.cUserId ? String(data.cUserId) : '',
+      cookies, // 传递 Cookie 给后续请求
+    };
+  }
+
+  /**
+   * 步骤 3：通过 location URL 获取 serviceToken
+   *
+   * @param {string} location - 重定向 URL（从 pollScanStatus 返回）
+   * @param {Object} cookies - 之前的 Cookie
+   * @returns {{ serviceToken: string, userId: string }}
+   */
+  static async getServiceToken(location, cookies = {}) {
+    const client = this._createClient(cookies);
+
+    logger.info('[XiaomiAuth] 正在获取 serviceToken...');
+
+    // location 会 302 重定向，Cookie 拦截器会自动提取 serviceToken
+    await client.get(location).catch(() => {
+      // 302 重定向会被 axios 拦截，忽略错误
+    });
+
+    const serviceToken = cookies.serviceToken || '';
+    const userId = cookies.userId || '';
+
+    if (!serviceToken) {
+      throw new Error('获取 serviceToken 失败');
+    }
+
+    logger.info('[XiaomiAuth] serviceToken 获取成功');
+
+    return { serviceToken, userId };
+  }
+
+  /**
+   * 步骤 4：获取音箱设备列表
+   *
+   * 注意：由于 xiaoii 的限制，无法在不初始化设备的情况下获取设备列表
+   * 因此此方法直接返回空数组，让用户手动输入设备名称
+   *
+   * @param {{ userId: string, passToken: string }} credentials
+   * @returns {Array<{ did: string, name: string, model: string }>}
+   */
+  static async getSpeakerDevices(credentials) {
+    const { userId, passToken } = credentials;
+
+    logger.info('[XiaomiAuth] 跳过自动获取设备列表，需要用户手动输入设备名称');
+
+    // 由于 xiaoii/lib/speaker 的 init() 方法在找不到设备时会崩溃
+    // 我们无法安全地获取设备列表，因此直接返回空数组
+    // 让用户手动输入米家 App 中的设备名称
+    return [];
+  }
+
+  /**
+   * 生成 Nonce（8 字节随机数 + 4 字节时间戳分钟数）
+   *
+   * @param {string} ssecurity - Base64 编码的安全密钥
+   * @returns {string} Base64 编码的 Nonce
+   */
+  static generateNonce(ssecurity) {
+    const secretBytes = Buffer.from(ssecurity, 'base64');
+    const randomBytes = crypto.randomBytes(8);
+    const timeBytes = Buffer.alloc(4);
+    // 当前分钟数（非秒数）
+    const minutes = Math.floor(Date.now() / 60000);
+    timeBytes.writeUInt32BE(minutes, 0);
+    const nonceBytes = Buffer.concat([randomBytes, timeBytes]);
+    return nonceBytes.toString('base64');
+  }
+
+  /**
+   * 生成签名 Nonce = SHA256(ssecurity + nonce)
+   *
+   * @param {string} ssecurity
+   * @param {string} nonce - Base64 编码
+   * @returns {string} Base64 编码的签名 Nonce
+   */
+  static signedNonce(ssecurity, nonce) {
+    const secretBytes = Buffer.from(ssecurity, 'base64');
+    const nonceBytes = Buffer.from(nonce, 'base64');
+    const hash = crypto.createHash('sha256')
+      .update(Buffer.concat([secretBytes, nonceBytes]))
+      .digest();
+    return hash.toString('base64');
+  }
+
+  /**
+   * 生成请求签名 = HMAC-SHA256(signedNonce, uri + signedNonce + nonce + data)
+   *
+   * @param {string} uri - API 路径
+   * @param {string} signedNonce
+   * @param {string} nonce
+   * @param {string} data - JSON 字符串
+   * @returns {string} Base64 编码的签名
+   */
+  static generateSignature(uri, signedNonce, nonce, data) {
+    const parts = [uri, signedNonce, nonce, `data=${data}`];
+    const signString = parts.join('&');
+    const signedNonceBytes = Buffer.from(signedNonce, 'base64');
+    return crypto.createHmac('sha256', signedNonceBytes)
+      .update(signString)
+      .digest('base64');
+  }
+
+  /**
+   * 生成加密请求参数
+   *
+   * @param {string} signedNonce
+   * @param {string} nonce
+   * @param {Object} params - 原始参数对象
+   * @returns {Object} 加密后的参数对象
+   */
+  static generateEncParams(signedNonce, nonce, params) {
+    const rc4Key = Buffer.from(signedNonce, 'base64');
+    const result = {};
+
+    for (const [key, value] of Object.entries(params)) {
+      if (key === '_nonce' || key === 'signature') {
+        result[key] = value;
+        continue;
+      }
+      // RC4 加密 value
+      const encrypted = this.encryptRc4(rc4Key, Buffer.from(value, 'utf-8'));
+      result[key] = encrypted.toString('base64');
+    }
+
+    return result;
+  }
+
+  /**
+   * RC4 加密
+   *
+   * @param {Buffer} key - 密钥
+   * @param {Buffer} data - 明文数据
+   * @returns {Buffer} 密文数据
+   */
+  static encryptRc4(key, data) {
+    const cipher = crypto.createCipheriv('rc4', key, null);
+    return Buffer.concat([cipher.update(data), cipher.final()]);
+  }
+
+  /**
+   * 一站式完成扫码登录：获取二维码 → 长轮询 → 提取凭证
+   * 返回二维码信息和一个 Promise，前端可自行决定何时轮询
+   *
+   * @returns {{ qrCodeUrl, lpUrl, loginUrl, timeout, cookies }}
+   */
+  static async initQRLogin() {
+    const qrData = await this.getLoginQR();
+    return {
+      qrCodeUrl: qrData.qr,
+      lpUrl: qrData.lp,
+      loginUrl: qrData.loginUrl,
+      timeout: qrData.timeout,
+      cookies: qrData._cookies,
+    };
+  }
+
+  /**
+   * 完成登录流程：从扫码结果中提取完整凭证
+   *
+   * @param {string} lpUrl - 长轮询 URL
+   * @param {Object} cookies - 之前的 Cookie
+   * @returns {{ userId, passToken, ssecurity, serviceToken }}
+   */
+  static async completeLogin(lpUrl, cookies) {
+    // 轮询等待扫码结果
+    const pollResult = await this.pollScanStatus(lpUrl, cookies);
+
+    if (pollResult.status !== 'confirmed') {
+      return pollResult;
+    }
+
+    // 获取 serviceToken
+    if (pollResult.location) {
+      try {
+        const tokenResult = await this.getServiceToken(
+          pollResult.location,
+          pollResult.cookies
+        );
+        pollResult.serviceToken = tokenResult.serviceToken;
+        if (tokenResult.userId) {
+          pollResult.userId = tokenResult.userId;
+        }
+      } catch (e) {
+        logger.warn('[XiaomiAuth] 获取 serviceToken 失败（不影响基本功能）:', e.message);
+      }
+    }
+
+    // 清理内部使用的 cookies 字段
+    delete pollResult.cookies;
+    delete pollResult.location;
+
+    return pollResult;
+  }
+}
+
+module.exports = XiaomiAuthService;

--- a/web/src/api/misound.js
+++ b/web/src/api/misound.js
@@ -1,0 +1,52 @@
+/**
+ * 小爱音箱渠道 API
+ *
+ * 提供扫码登录、绑定确认等接口调用
+ */
+
+import request from '@/utils/request'
+
+/**
+ * 初始化扫码登录
+ * 获取小米账号的二维码 URL
+ *
+ * @returns {{ sessionId, qrCodeUrl, loginUrl, timeout }}
+ */
+export const initMiQRLogin = () => {
+  return request.post('/channels/misound/qr/init')
+}
+
+/**
+ * 轮询扫码状态
+ * 长轮询等待用户扫码结果
+ *
+ * @param {string} sessionId - 会话 ID（从 initMiQRLogin 获取）
+ * @returns {{ status, userId?, passToken? }}
+ */
+export const pollMiQRStatus = (sessionId) => {
+  return request.get('/channels/misound/qr/status', {
+    params: { sessionId },
+    timeout: 330000, // 长轮询超时 330 秒（比服务端多 30 秒）
+  })
+}
+
+/**
+ * 确认绑定（创建渠道）
+ *
+ * @param {{ userId, passToken, did, name?, ttsMode? }} data
+ * @returns {Object} 创建的渠道对象
+ */
+export const confirmMiBind = (data) => {
+  return request.post('/channels/misound/qr/confirm', data)
+}
+
+/**
+ * 重新绑定已有渠道
+ *
+ * @param {number} channelId - 渠道 ID
+ * @param {{ userId, passToken, did?, ttsMode? }} data
+ * @returns {Object} 更新后的渠道对象
+ */
+export const rebindMiChannel = (channelId, data) => {
+  return request.put(`/channels/misound/qr/${channelId}/rebind`, data)
+}

--- a/web/src/components/MisoundBindDialog.vue
+++ b/web/src/components/MisoundBindDialog.vue
@@ -1,0 +1,482 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :title="mode === 'rebind' ? '重新绑定小爱音箱' : '绑定小爱音箱'"
+    width="500px"
+    :close-on-click-modal="false"
+    :close-on-press-escape="step !== 'success'"
+    :show-close="step !== 'polling'"
+    @close="handleClose"
+  >
+    <!-- 步骤 1: 选择登录方式 -->
+    <div v-if="step === 'select'" class="space-y-4">
+      <!-- 已有账号列表 -->
+      <div v-if="existingAccounts.length > 0">
+        <p class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">选择已登录的小米账号</p>
+        <div class="space-y-2 mb-4">
+          <div
+            v-for="account in existingAccounts"
+            :key="account.userId"
+            class="flex items-center justify-between p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:border-blue-500 cursor-pointer transition-colors"
+            :class="{ 'border-blue-500 bg-blue-50 dark:bg-blue-900/20': selectedAccount?.userId === account.userId }"
+            @click="selectedAccount = account"
+          >
+            <div class="flex-1">
+              <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                小米账号 ({{ account.userId }})
+              </p>
+              <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                已绑定 {{ account.channelCount }} 个设备
+              </p>
+            </div>
+            <el-icon v-if="selectedAccount?.userId === account.userId" class="text-blue-500 text-xl">
+              <CircleCheck />
+            </el-icon>
+          </div>
+        </div>
+        <el-divider>或</el-divider>
+      </div>
+
+      <!-- 扫码登录新账号 -->
+      <el-button type="primary" class="w-full" @click="startQRLogin">
+        扫码登录新的小米账号
+      </el-button>
+    </div>
+
+    <!-- 步骤 2: 获取二维码 -->
+    <div v-else-if="step === 'loading'" class="text-center py-12">
+      <el-icon class="is-loading text-3xl text-gray-400"><Loading /></el-icon>
+      <p class="text-sm text-gray-400 mt-3">正在获取登录二维码...</p>
+    </div>
+
+    <!-- 步骤 3: 展示二维码，等待扫码 -->
+    <div v-else-if="step === 'qrcode' || step === 'polling'" class="text-center">
+      <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        请使用<strong>小米手机/米家APP</strong>扫描下方二维码登录小米账号
+      </p>
+
+      <!-- 二维码 -->
+      <div class="inline-block p-3 bg-white rounded-lg border border-gray-200">
+        <QrcodeVue :value="qrCodeUrl" :size="220" level="M" />
+      </div>
+
+      <!-- 备选：手动打开链接 -->
+      <div class="mt-3">
+        <p class="text-xs text-gray-400 mb-1">无法扫码？点击下方链接手动登录：</p>
+        <a
+          :href="loginUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-xs text-blue-500 hover:text-blue-700 break-all"
+        >{{ loginUrl }}</a>
+      </div>
+
+      <!-- 状态提示 -->
+      <div class="mt-4">
+        <div v-if="step === 'polling'" class="flex items-center justify-center gap-2 text-sm text-gray-500">
+          <el-icon class="is-loading"><Loading /></el-icon>
+          <span>等待扫码中，请在小米手机上确认登录...</span>
+        </div>
+        <p v-if="step === 'qrcode'" class="text-sm text-amber-600">
+          二维码有效期约 5 分钟
+        </p>
+      </div>
+
+      <!-- 返回按钮 -->
+      <div v-if="existingAccounts.length > 0" class="mt-4">
+        <el-button text @click="step = 'select'">
+          <el-icon class="mr-1"><ArrowLeft /></el-icon>
+          返回选择账号
+        </el-button>
+      </div>
+    </div>
+
+    <!-- 步骤 4: 配置设备信息 -->
+    <div v-else-if="step === 'config'" class="space-y-4">
+      <!-- 登录成功提示 -->
+      <div v-if="!selectedAccount" class="flex items-center gap-2 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded-lg mb-4">
+        <el-icon class="text-green-600"><SuccessFilled /></el-icon>
+        <span class="text-sm text-green-700 dark:text-green-300">小米账号登录成功</span>
+      </div>
+
+      <!-- 配置表单 -->
+      <el-form label-position="top">
+        <el-form-item label="设备名称" required>
+          <el-input
+            v-model="deviceName"
+            placeholder="请输入设备名称，如：客厅小爱"
+            maxlength="50"
+          />
+          <p class="text-xs text-gray-500 mt-1">
+            设备名称必须与米家 App 中的名称完全一致（注意大小写、空格）
+          </p>
+        </el-form-item>
+
+        <el-form-item label="渠道名称">
+          <el-input
+            v-model="channelName"
+            placeholder="小爱音箱"
+            maxlength="50"
+          />
+        </el-form-item>
+
+        <el-form-item label="TTS 模式">
+          <el-select v-model="ttsMode" class="w-full">
+            <el-option label="自动（推荐）" value="auto" />
+            <el-option label="指令模式" value="command" />
+            <el-option label="默认链路" value="default" />
+          </el-select>
+          <p class="text-xs text-gray-500 mt-1">
+            auto=智能选择最优方式；command=仅用MiOT指令；default=仅用MiNA默认链路
+          </p>
+        </el-form-item>
+      </el-form>
+    </div>
+
+    <!-- 步骤 5: 绑定成功 -->
+    <div v-else-if="step === 'success'" class="text-center py-8">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 mb-4">
+        <el-icon class="text-3xl text-green-600 dark:text-green-400"><SuccessFilled /></el-icon>
+      </div>
+      <p class="text-lg font-medium text-green-700 dark:text-green-400 mb-2">绑定成功</p>
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        已绑定到「{{ boundDeviceName }}」
+      </p>
+    </div>
+
+    <!-- 错误状态 -->
+    <div v-else-if="step === 'error'" class="text-center py-8">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 dark:bg-red-900/30 mb-4">
+        <el-icon class="text-3xl text-red-600 dark:text-red-400"><WarningFilled /></el-icon>
+      </div>
+      <p class="text-lg font-medium text-red-700 dark:text-red-400 mb-2">操作失败</p>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ errorMsg }}</p>
+      <el-button type="primary" @click="reset">重新开始</el-button>
+    </div>
+
+    <!-- 二维码过期 -->
+    <div v-else-if="step === 'expired'" class="text-center py-8">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-amber-100 dark:bg-amber-900/30 mb-4">
+        <el-icon class="text-3xl text-amber-600 dark:text-amber-400"><WarningFilled /></el-icon>
+      </div>
+      <p class="text-lg font-medium text-amber-700 dark:text-amber-400 mb-2">二维码已过期</p>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">请重新获取二维码</p>
+      <el-button type="primary" @click="startQRLogin">刷新二维码</el-button>
+    </div>
+
+    <template #footer>
+      <template v-if="step === 'select'">
+        <el-button @click="handleClose">取消</el-button>
+        <el-button
+          type="primary"
+          :disabled="!selectedAccount"
+          @click="useExistingAccount"
+        >
+          使用选中的账号
+        </el-button>
+      </template>
+      <template v-else-if="step === 'config'">
+        <el-button @click="handleClose">取消</el-button>
+        <el-button
+          type="primary"
+          :disabled="!deviceName.trim() || binding"
+          :loading="binding"
+          @click="handleConfirm"
+        >
+          确认绑定
+        </el-button>
+      </template>
+      <template v-else-if="step === 'success'">
+        <el-button type="primary" @click="handleSuccess">完成</el-button>
+      </template>
+      <template v-else-if="step !== 'loading' && step !== 'polling'">
+        <el-button @click="handleClose">取消</el-button>
+      </template>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { ElMessage } from 'element-plus'
+import { Loading, SuccessFilled, WarningFilled, CircleCheck, ArrowLeft } from '@element-plus/icons-vue'
+import QrcodeVue from 'qrcode.vue'
+import { initMiQRLogin, pollMiQRStatus, confirmMiBind, rebindMiChannel } from '@/api/misound'
+import { getChannels } from '@/api/channel'
+
+const props = defineProps({
+  visible: Boolean,
+  mode: { type: String, default: 'create' },
+  channelId: Number,
+})
+const emit = defineEmits(['update:visible', 'success'])
+
+// 状态
+const step = ref('idle')  // idle | select | loading | qrcode | polling | config | success | error | expired
+const errorMsg = ref('')
+
+// 已有账号列表
+const existingAccounts = ref([])
+const selectedAccount = ref(null)
+
+// 扫码相关
+const qrCodeUrl = ref('')
+const loginUrl = ref('')
+const sessionId = ref('')
+const credentials = ref({})
+
+// 配置表单
+const deviceName = ref('')
+const channelName = ref('小爱音箱')
+const ttsMode = ref('auto')
+const binding = ref(false)
+const boundDeviceName = ref('')
+
+// 防止重复轮询
+let isPolling = false
+
+watch(() => props.visible, (val) => {
+  if (val) {
+    loadExistingAccounts()
+  } else {
+    cleanup()
+  }
+})
+
+/**
+ * 加载已有的小米账号
+ */
+async function loadExistingAccounts() {
+  try {
+    const res = await getChannels()
+    if (res.success && res.data) {
+      // 从已有的 misound 渠道中提取唯一的账号
+      const channels = res.data.filter(ch => ch.channel_type === 'misound' && ch.config)
+      const accountMap = new Map()
+      
+      channels.forEach(channel => {
+        const userId = channel.config.userId
+        if (userId) {
+          if (!accountMap.has(userId)) {
+            accountMap.set(userId, {
+              userId,
+              passToken: channel.config.passToken,
+              channelCount: 0,
+            })
+          }
+          accountMap.get(userId).channelCount++
+        }
+      })
+      
+      existingAccounts.value = Array.from(accountMap.values())
+      
+      // 如果有已有账号，显示选择界面；否则直接进入扫码
+      if (existingAccounts.value.length > 0) {
+        step.value = 'select'
+      } else {
+        startQRLogin()
+      }
+    } else {
+      // 没有已有账号，直接扫码
+      startQRLogin()
+    }
+  } catch (error) {
+    console.error('加载已有账号失败:', error)
+    // 出错时也直接进入扫码
+    startQRLogin()
+  }
+}
+
+/**
+ * 使用已有账号
+ */
+function useExistingAccount() {
+  if (!selectedAccount.value) {
+    ElMessage.warning('请选择一个账号')
+    return
+  }
+  
+  credentials.value = {
+    userId: selectedAccount.value.userId,
+    passToken: selectedAccount.value.passToken,
+  }
+  
+  step.value = 'config'
+}
+
+/**
+ * 开始扫码登录
+ */
+function startQRLogin() {
+  selectedAccount.value = null
+  fetchQRCode()
+}
+
+/**
+ * 获取登录二维码
+ */
+async function fetchQRCode() {
+  step.value = 'loading'
+  errorMsg.value = ''
+
+  try {
+    const res = await initMiQRLogin()
+    if (res.success && res.data) {
+      qrCodeUrl.value = res.data.qrCodeUrl
+      loginUrl.value = res.data.loginUrl
+      sessionId.value = res.data.sessionId
+      step.value = 'qrcode'
+
+      setTimeout(() => {
+        if (props.visible && step.value === 'qrcode') {
+          startPolling()
+        }
+      }, 1000)
+    } else {
+      step.value = 'error'
+      errorMsg.value = res.message || '获取二维码失败'
+    }
+  } catch (error) {
+    step.value = 'error'
+    errorMsg.value = error.message || '获取二维码失败，请检查网络连接'
+  }
+}
+
+/**
+ * 开始轮询扫码状态
+ */
+function startPolling() {
+  if (isPolling) return
+  isPolling = true
+  step.value = 'polling'
+  doPoll()
+}
+
+/**
+ * 执行一次轮询
+ */
+async function doPoll() {
+  if (!sessionId.value || !isPolling) return
+
+  try {
+    const res = await pollMiQRStatus(sessionId.value)
+
+    if (!res.success || !res.data) {
+      setTimeout(doPoll, 3000)
+      return
+    }
+
+    switch (res.data.status) {
+      case 'confirmed':
+        isPolling = false
+        credentials.value = {
+          userId: res.data.userId,
+          passToken: res.data.passToken,
+        }
+        step.value = 'config'
+        break
+
+      case 'expired':
+        isPolling = false
+        step.value = 'expired'
+        break
+
+      case 'canceled':
+        isPolling = false
+        step.value = 'expired'
+        errorMsg.value = '用户取消了登录'
+        break
+
+      case 'failed':
+        isPolling = false
+        step.value = 'error'
+        errorMsg.value = res.data.message || '扫码失败'
+        break
+
+      default:
+        setTimeout(doPoll, 2000)
+        break
+    }
+  } catch (error) {
+    setTimeout(doPoll, 5000)
+  }
+}
+
+/**
+ * 确认绑定
+ */
+async function handleConfirm() {
+  const did = deviceName.value.trim()
+  
+  if (!did) {
+    ElMessage.warning('请输入设备名称')
+    return
+  }
+
+  binding.value = true
+
+  try {
+    let res
+    if (props.mode === 'rebind' && props.channelId) {
+      res = await rebindMiChannel(props.channelId, {
+        userId: credentials.value.userId,
+        passToken: credentials.value.passToken,
+        did,
+        ttsMode: ttsMode.value,
+      })
+    } else {
+      res = await confirmMiBind({
+        userId: credentials.value.userId,
+        passToken: credentials.value.passToken,
+        did,
+        name: channelName.value || '小爱音箱',
+        ttsMode: ttsMode.value,
+      })
+    }
+
+    if (res.success) {
+      boundDeviceName.value = channelName.value || did
+      step.value = 'success'
+    } else {
+      ElMessage.error(res.message || '绑定失败')
+    }
+  } catch (error) {
+    ElMessage.error(error.message || '绑定失败')
+  } finally {
+    binding.value = false
+  }
+}
+
+function handleClose() {
+  if (step.value === 'polling') return
+  cleanup()
+  emit('update:visible', false)
+}
+
+function handleSuccess() {
+  emit('success')
+  cleanup()
+  emit('update:visible', false)
+}
+
+function reset() {
+  cleanup()
+  loadExistingAccounts()
+}
+
+function cleanup() {
+  isPolling = false
+  step.value = 'idle'
+  qrCodeUrl.value = ''
+  loginUrl.value = ''
+  sessionId.value = ''
+  credentials.value = {}
+  selectedAccount.value = null
+  deviceName.value = ''
+  channelName.value = '小爱音箱'
+  ttsMode.value = 'auto'
+  binding.value = false
+  boundDeviceName.value = ''
+  errorMsg.value = ''
+}
+</script>


### PR DESCRIPTION
## 功能概述
实现小米账号扫码登录，支持选择已有账号或扫码新账号，优化小爱音箱渠道的绑定流程。

## 主要功能
- 实现小米账号扫码登录流程
- 支持选择已有小米账号或扫码登录新账号
- 手动输入设备名称（与米家 App 中的名称一致）
- 支持 TTS 模式选择（auto/command/default）
- 优化用户体验，避免重复扫码

## 技术实现
**后端新增文件：**
- server/src/services/xiaomi-auth.service.js - 小米云认证服务
- server/src/controllers/misound.controller.js - 小爱音箱控制器
- server/src/routes/misound.routes.js - 路由配置

**前端新增文件：**
- web/src/components/MisoundBindDialog.vue - 绑定对话框组件
- web/src/api/misound.js - API 接口

## 用户流程
- 首次绑定：扫码登录 → 输入设备名 → 确认绑定
- 已有账号：选择已有账号/扫码登录新账号 → 输入设备名 → 确认绑定

## 技术细节
### 小米账号扫码登录流程
1. 获取小米账号登录二维码
2. 长轮询等待用户扫码确认（300秒超时）
3. 提取 userId 和 passToken
4. 存储凭证用于后续设备绑定

### 账号管理优化
- 自动检测已绑定的小米账号（从现有渠道中提取）
- 支持一个小米账号绑定多个设备
- 避免重复扫码，提升用户体验

### 安全性考虑
- Session 管理（5分钟过期）
- 定期清理过期会话
- 支持代理配置（HTTP_PROXY/HTTPS_PROXY）
- 完善的错误处理

## 测试说明
- ✅ 扫码登录流程测试通过
- ✅ 账号选择功能测试通过
- ✅ 设备绑定功能测试通过
- ✅ 错误处理测试通过
- ✅ 二维码过期处理测试通过

## 解决的问题
解决了小爱音箱渠道绑定流程复杂的问题，用户不再需要手动获取和配置 userId、passToken 等参数。

## 兼容性
- ✅ 向后兼容：不影响现有已绑定的小爱音箱渠道
- ✅ 支持重新绑定功能
- ✅ 与现有渠道系统完全集成