### PR TITLE
Add a security policy (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied to the latest 1.x release. Please update to the
+current version before reporting so we can confirm the issue on current code.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.14.x  | :white_check_mark: |
+| < 1.14  | :x:                |
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for security vulnerabilities. Public issues are
+visible to everyone and can expose users before a fix is available.
+
+Instead, report privately through one of these channels:
+
+1. **GitHub private vulnerability reporting (preferred).** Go to the repository
+   **Security** tab and choose **Report a vulnerability**. If this option is not
+   visible, a maintainer can enable it under **Settings > Security > Private
+   vulnerability reporting**.
+2. **Direct contact.** If private reporting is not enabled, open a short issue that
+   asks for a private contact and shares no technical details, and a maintainer will
+   follow up.
+
+### What to include
+
+- A description of the vulnerability and its impact
+- Steps to reproduce, or a proof of concept
+- The affected version, endpoint, or file if known
+- Any suggested fix (optional but appreciated)
+
+### What to expect
+
+- An acknowledgement of your report, typically within a few days
+- An assessment of severity and a plan for a fix
+- Coordinated disclosure: details are published after a fix is available, with
+  credit to the reporter unless you prefer to remain anonymous
+
+Thank you for helping keep this project and its users safe.


### PR DESCRIPTION
Adds a security policy so vulnerabilities can be reported responsibly through a private channel instead of a public issue. Happy to adjust any wording to your preference.